### PR TITLE
Support voice in short name format

### DIFF
--- a/R/create_ssml.R
+++ b/R/create_ssml.R
@@ -63,7 +63,7 @@ ms_create_ssml = function(
 ms_voice_info = function(voice) {
   stopifnot(length(voice) == 1 & is.character(voice))
   df = ms_locale_df()
-  keep = df$locale %in% voice
+  keep = df$locale %in% voice | df$short_name %in% voice
   if (!any(keep)) {
     stop("Voice given is not a recognized voice! See ms_locale_df()")
   }
@@ -71,6 +71,6 @@ ms_voice_info = function(voice) {
   df = df[1, , drop = FALSE]
   L = list(gender = df$Gender,
            full_name = df$locale,
-           language = df$language)
+           language = df$code)
   return(L)
 }

--- a/tests/testthat/test-ssml.R
+++ b/tests/testthat/test-ssml.R
@@ -1,0 +1,10 @@
+test_that(desc = "Create SSML properly with given parameters", {
+
+  expect_equal(ms_create_ssml("created with default voice"),
+               "<speak version='1.0' xml:lang='en-US'><voice xml:lang='en-US' xml:gender='Female' name='Microsoft Server Speech Text to Speech Voice (en-US, JessaRUS)'>created with default voice</voice></speak>")
+  expect_error(ms_create_ssml("this is an error", voice = "invalid voice name"))
+  expect_equal(ms_create_ssml("created with given voice", voice = "Microsoft Server Speech Text to Speech Voice (zh-CN, Yaoyao, Apollo)"),
+               "<speak version='1.0' xml:lang='zh-CN'><voice xml:lang='zh-CN' xml:gender='Female' name='Microsoft Server Speech Text to Speech Voice (zh-CN, Yaoyao, Apollo)'>created with given voice</voice></speak>")
+  expect_equal(ms_create_ssml("created with given voice in short name", voice = "vi-VN-An"),
+               "<speak version='1.0' xml:lang='vi-VN'><voice xml:lang='vi-VN' xml:gender='Male' name='Microsoft Server Speech Text to Speech Voice (vi-VN, An)'>created with given voice in short name</voice></speak>")
+})


### PR DESCRIPTION
Address part of #10.

* When voice given to `ms_create_ssml` is in short_name format, it should work as well.
* Also use the correct format of language code.
* Added several test cases to cover these.